### PR TITLE
Add Jade template support

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -16,8 +16,8 @@ There are three tasks that are accessable to developers via the terminal. This i
 3. Takes an `importer.less` file found in `/assets/styles` and compiles your less files into css based on what's in this file. Having one less file importing all of your other less files is a convention that many front end developers use, and the name of this file can be changed in the `/tasks/config/less.js` file. The compiled css will be placed in `/.tmp/public/styles/importer.css'
 4. Copies the rest of the assets, except coffeescript and less files, in the `/assest` directory into the `/.tmp/public` directory.
 5. Compiles coffeescript files in `/assets/js` to javascript and places them in the `/.tmp/public/js` directory.
-6. Automatically injects `<script>` and `<link>` tags into any HTML located in `/.tmp/public` or EJS file in `/views`.
-The important thing to understand is that this asset injection should be placed in files that act as a layout file for your app. For single page apps this would be something like an `index.html` file and for apps that send server side views this should be something like a `layout.ejs` file. Usage for how to injet files is showin in `tasks/config/sails-linker.js` or can be found [here](https://github.com/Zolmeister/grunt-sails-linker). A more detailed description of this task can be found below.
+6. Automatically injects `<script>` and `<link>` tags into any HTML located in `/.tmp/public`, EJS or JADE file in `/views`.
+The important thing to understand is that this asset injection should be placed in files that act as a layout file for your app. For single page apps this would be something like an `index.html` file and for apps that send server side views this should be something like a `layout.ejs` or `layout.jade` file. Usage for how to injet files is showin in `tasks/config/sails-linker.js` or can be found [here](https://github.com/Zolmeister/grunt-sails-linker). A more detailed description of this task can be found below.
 7. Sets up a watch task that will run this entire task again if there are changes detected in the `/assets` directory or the `tasks/pipeline.js` file. This task is optimized so that instead of deleting entire directories and files, it just syncs changes that were made.
 
 ### sails build
@@ -52,7 +52,7 @@ Lets say we are working on a single page app in our sails project. Since it is a
 </html>
 ```
 
-Ok, so we have our `index.html` and we want to start placing in our assets. The hard way would be to do it manually. This is not ideal, considering it really annoying having to remember to include or take away `<script>` or `<link>` tags everytime we create or delete a js or css asset. This is exaclty what sails linker is for. Instead of manually including assets, we simply include some comments that sails-linker looks for. It can then inject the relevent files into our `index.html` for us. By default, sails-linker looks for  `<!--STYLES-->` and `<!--STYLES END-->` for styles. For javascript, its `<!--SCRIPTS-->` and `<!--SCRIPTS END-->`.
+Ok, so we have our `index.html` and we want to start placing in our assets. The hard way would be to do it manually. This is not ideal, considering it really annoying having to remember to include or take away `<script>` or `<link>` tags everytime we create or delete a js or css asset. This is exaclty what sails linker is for. Instead of manually including assets, we simply include some comments that sails-linker looks for. It can then inject the relevent files into our `index.html` for us. By default, sails-linker looks for  `<!--STYLES-->` and `<!--STYLES END-->` for styles. For javascript, its `<!--SCRIPTS-->` and `<!--SCRIPTS END-->`. In jade template, sails-linker looks for  `// STYLES` and `// STYLES END` for styles. For javascript, its `// SCRIPTS` and `// SCRIPTS END`.
 
 ```html
 <!DOCTYPE html>
@@ -60,7 +60,7 @@ Ok, so we have our `index.html` and we want to start placing in our assets. The 
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE-edge,chrome=1">
-    <titel></title>
+    <title></title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
 
@@ -79,6 +79,28 @@ Ok, so we have our `index.html` and we want to start placing in our assets. The 
 </html>
 ```
 
+```jade
+doctype html
+html
+  head
+    meta(charset="utf-8")
+    meta(http-equiv="X-UA-Compatible", content="IE-edge,chrome=1")
+    title
+    meta(name="description", content="")
+    meta(name="viewport", content="width=device-width")
+
+    //- link tags are going to be injected here
+    // STYLES
+    // STYLES END
+
+  body
+    h1 My app!
+
+    //- script tags are going to be injected here
+    // SCRIPT
+    // SCRIPTS END
+```
+
 Let's say we have `assets/styles/main.css`, `assets/styles/a.js`,  and `assets/styles/b.js`. Given our setup, once we run `sails lift` our `index.html` will look like this.
 
 ```html
@@ -87,7 +109,7 @@ Let's say we have `assets/styles/main.css`, `assets/styles/a.js`,  and `assets/s
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE-edge,chrome=1">
-    <titel></title>
+    <title></title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
 

--- a/templates/tasks/config/sails-linker.js
+++ b/templates/tasks/config/sails-linker.js
@@ -145,6 +145,121 @@ module.exports = function(grunt) {
 				'views/**/*.html': ['.tmp/public/jst.js'],
 				'views/**/*.ejs': ['.tmp/public/jst.js']
 			}
+		},
+
+		devJsJade: {
+			options: {
+				startTag: '// SCRIPTS',
+				endTag: '// SCRIPTS END',
+				fileTmpl: 'script(src="%s")',
+				appRoot: '.tmp/public'
+			},
+			files: {
+				'views/**/*.jade': require('../pipeline').jsFilesToInject
+			}
+		},
+
+		devJsRelativeJade: {
+			options: {
+				startTag: '// SCRIPTS',
+				endTag: '// SCRIPTS END',
+				fileTmpl: 'script(src="%s")',
+				appRoot: '.tmp/public',
+				relative: true
+			},
+			files: {
+				'views/**/*.jade': require('../pipeline').jsFilesToInject
+			}
+		},
+
+		prodJsJade: {
+			options: {
+				startTag: '// SCRIPTS',
+				endTag: '// SCRIPTS END',
+				fileTmpl: 'script(src="%s")',
+				appRoot: '.tmp/public'
+			},
+			files: {
+				'views/**/*.jade': ['.tmp/public/min/production.js']
+			}
+		},
+
+		prodJsRelativeJade: {
+			options: {
+				startTag: '// SCRIPTS',
+				endTag: '// SCRIPTS END',
+				fileTmpl: 'script(src="%s")',
+				appRoot: '.tmp/public',
+				relative: true
+			},
+			files: {
+				'views/**/*.jade': ['.tmp/public/min/production.js']
+			}
+		},
+
+		devStylesJade: {
+			options: {
+				startTag: '// STYLES',
+				endTag: '// STYLES END',
+				fileTmpl: 'link(rel="stylesheet", href="%s")',
+				appRoot: '.tmp/public'
+			},
+
+			files: {
+				'views/**/*.jade': require('../pipeline').cssFilesToInject
+			}
+		},
+
+		devStylesRelativeJade: {
+			options: {
+				startTag: '// STYLES',
+				endTag: '// STYLES END',
+				fileTmpl: 'link(rel="stylesheet", href="%s")',
+				appRoot: '.tmp/public',
+				relative: true
+			},
+
+			files: {
+				'views/**/*.jade': require('../pipeline').cssFilesToInject
+			}
+		},
+
+		prodStylesJade: {
+			options: {
+				startTag: '// STYLES',
+				endTag: '// STYLES END',
+				fileTmpl: 'link(rel="stylesheet", href="%s")',
+				appRoot: '.tmp/public'
+			},
+			files: {
+				'views/**/*.jade': ['.tmp/public/min/production.css']
+			}
+		},
+
+		prodStylesRelativeJade: {
+			options: {
+				startTag: '// STYLES',
+				endTag: '// STYLES END',
+				fileTmpl: 'link(rel="stylesheet", href="%s")',
+				appRoot: '.tmp/public',
+				relative: true
+			},
+			files: {
+				'views/**/*.jade': ['.tmp/public/min/production.css']
+			}
+		},
+
+		// Bring in JST template object
+		devTplJade: {
+			options: {
+				startTag: '// TEMPLATES',
+				endTag: '// TEMPLATES END',
+				fileTmpl: 'script(type="text/javascript", src="%s")',
+				appRoot: '.tmp/public'
+			},
+			files: {
+				'views/**/*.jade': ['.tmp/public/jst.js']
+			}
 		}
 	});
 

--- a/templates/tasks/register/linkAssets.js
+++ b/templates/tasks/register/linkAssets.js
@@ -2,6 +2,9 @@ module.exports = function (grunt) {
 	grunt.registerTask('linkAssets', [
 		'sails-linker:devJs',
 		'sails-linker:devStyles',
-		'sails-linker:devTpl'
+		'sails-linker:devTpl',
+		'sails-linker:devJsJade',
+		'sails-linker:devStylesJade',
+		'sails-linker:devTplJade'
 	]);
 };

--- a/templates/tasks/register/linkAssetsBuild.js
+++ b/templates/tasks/register/linkAssetsBuild.js
@@ -2,6 +2,9 @@ module.exports = function (grunt) {
 	grunt.registerTask('linkAssetsBuild', [
 		'sails-linker:devJsRelative',
 		'sails-linker:devStylesRelative',
-		'sails-linker:devTpl'
+		'sails-linker:devTpl',
+		'sails-linker:devJsRelativeJade',
+		'sails-linker:devStylesRelativeJade',
+		'sails-linker:devTplJade'
 	]);
 };

--- a/templates/tasks/register/linkAssetsBuildProd.js
+++ b/templates/tasks/register/linkAssetsBuildProd.js
@@ -2,6 +2,9 @@ module.exports = function (grunt) {
 	grunt.registerTask('linkAssetsBuildProd', [
 		'sails-linker:prodJsRelative',
 		'sails-linker:prodStylesRelative',
-		'sails-linker:devTpl'
+		'sails-linker:devTpl',
+		'sails-linker:prodJsRelativeJade',
+		'sails-linker:prodStylesRelativeJade',
+		'sails-linker:devTplJade'
 	]);
 };

--- a/templates/tasks/register/prod.js
+++ b/templates/tasks/register/prod.js
@@ -6,6 +6,9 @@ module.exports = function (grunt) {
 		'cssmin',
 		'sails-linker:prodJs',
 		'sails-linker:prodStyles',
-		'sails-linker:devTpl'
+		'sails-linker:devTpl',
+		'sails-linker:prodJsJade',
+		'sails-linker:prodStylesJade',
+		'sails-linker:devTplJade'
 	]);
 };


### PR DESCRIPTION
Add support to automatically injects `<script>` and `<link>` tags into any JADE file in `/views`.
