### PR TITLE
'sails www' command can't build exactly directory

### DIFF
--- a/templates/tasks/config/copy.js
+++ b/templates/tasks/config/copy.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
 				expand: true,
 				cwd: '.tmp/public',
 				src: ['**/*'],
-				dest: 'www'
+				dest: process.env.PWD + '/www'
 			}]
 		}
 	});


### PR DESCRIPTION
# sails www
this command should make 'www' directory on current directory.
ref) https://github.com/balderdashy/sails/blob/master/bin/sails-www.js

but now, 'www' directory will be build on root directory of the sails project.

I changed the destination of configuration such as adding 'process.env.PWD'.