### PR TITLE
add ".less" filter to `sync`

### DIFF
--- a/templates/tasks/config/sync.js
+++ b/templates/tasks/config/sync.js
@@ -17,7 +17,7 @@ module.exports = function(grunt) {
 		dev: {
 			files: [{
 				cwd: './assets',
-				src: ['**/*.!(coffee)'],
+				src: ['**/*.!(coffee|less)'],
 				dest: '.tmp/public'
 			}]
 		}


### PR DESCRIPTION
`sync` should work in accordance with `copy`, not copying `.less` files.