### PR TITLE
Do not watch inside node_modules folders

### DIFF
--- a/templates/tasks/config/watch.js
+++ b/templates/tasks/config/watch.js
@@ -18,12 +18,12 @@ module.exports = function(grunt) {
 		api: {
 
 			// API files to watch:
-			files: ['api/**/*']
+			files: ['api/**/*', '!**/node_modules/**/*']
 		},
 		assets: {
 
 			// Assets to watch:
-			files: ['assets/**/*', 'tasks/pipeline.js'],
+			files: ['assets/**/*', 'tasks/pipeline.js', '!**/node_modules/**/*'],
 
 			// When assets are changed:
 			tasks: ['syncAssets' <%- linker ? ", 'linkAssets'" : '' %>]

--- a/templates/tasks/config/watch.js
+++ b/templates/tasks/config/watch.js
@@ -18,12 +18,12 @@ module.exports = function(grunt) {
 		api: {
 
 			// API files to watch:
-			files: ['api/**/*', '!**/node_modules/**/*']
+			files: ['api/**/*', '!**/node_modules/**']
 		},
 		assets: {
 
 			// Assets to watch:
-			files: ['assets/**/*', 'tasks/pipeline.js', '!**/node_modules/**/*'],
+			files: ['assets/**/*', 'tasks/pipeline.js', '!**/node_modules/**'],
 
 			// When assets are changed:
 			tasks: ['syncAssets' <%- linker ? ", 'linkAssets'" : '' %>]


### PR DESCRIPTION
If you use a custom adapter, grunt is watching inside `node_modules`.

Then... https://github.com/gruntjs/grunt-contrib-watch/issues/75 happened