### PR TITLE
fix grunt ignore

### DIFF
--- a/templates/tasks/pipeline.js
+++ b/templates/tasks/pipeline.js
@@ -54,11 +54,20 @@ var templateFilesToInject = [
 // (i.e. where the other Grunt tasks spit them out, or in some cases, where
 // they reside in the first place)
 module.exports.cssFilesToInject = cssFilesToInject.map(function(path) {
-  return '.tmp/public/' + path;
+  var tmpPath = '.tmp/public/';
+  if (path.substring(0,1) == '!')
+    return '!' + tmpPath + path.substring(1);
+  return tmpPath + path;
 });
 module.exports.jsFilesToInject = jsFilesToInject.map(function(path) {
-  return '.tmp/public/' + path;
+  var tmpPath = '.tmp/public/';
+  if (path.substring(0,1) == '!')
+    return '!' + tmpPath + path.substring(1);
+  return tmpPath + path;
 });
 module.exports.templateFilesToInject = templateFilesToInject.map(function(path) {
-  return 'assets/' + path;
+  var tmpPath = 'assets/';
+  if (path.substring(0,1) == '!')
+    return '!' + tmpPath + path.substring(1);
+  return tmpPath + path;
 });


### PR DESCRIPTION
The grunt glob patterns define starting with a `!` as a NOT. However the map function prepended the relative assets to the given paths, resulting in thigngs lik `.tmp/public/!js/foo.js`, which of course did not match anything. This PR fixes the generator to honor the leading `!`.

There is still a pitfall, the exclusions must happen after a general match. This is documented in the [grunt docs](http://gruntjs.com/configuring-tasks#globbing-patterns) though.

Fixes balderdashy/sails#2375