### PR TITLE
added include paths to less grunt task

### DIFF
--- a/templates/tasks/config/less.js
+++ b/templates/tasks/config/less.js
@@ -8,21 +8,24 @@
  * dependencies, mixins, variables, resets, etc. before other stylesheets)
  *
  * For usage docs see:
- * 		https://github.com/gruntjs/grunt-contrib-less
+ *      https://github.com/gruntjs/grunt-contrib-less
  */
 module.exports = function(grunt) {
 
-	grunt.config.set('less', {
-		dev: {
-			files: [{
-				expand: true,
-				cwd: 'assets/styles/',
-				src: ['importer.less'],
-				dest: '.tmp/public/styles/',
-				ext: '.css'
-			}]
-		}
-	});
+    grunt.config.set('less', {
+        dev: {
+            files: [{
+                expand: true,
+                cwd: 'assets/styles/',
+                src: ['importer.less'],
+                dest: '.tmp/public/styles/',
+                ext: '.css'
+            }],
+            options: {
+                paths: ['bower_components', 'node_modules']
+            }
+        }
+    });
 
-	grunt.loadNpmTasks('grunt-contrib-less');
+    grunt.loadNpmTasks('grunt-contrib-less');
 };


### PR DESCRIPTION
it allows to `@import` from bower and node modules:

```
# console
npm install bootstrap

# assets/styles/importer.less
@import "bootstrap/less/bootstrap.less"
``